### PR TITLE
fix/ TokenUtils.encode_text_to_tokens result

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Interactively talk with OpenAI sample bot, GPT Assistant, in UI.
 
   - Result
 
-    <img width="375" alt="image" src="https://github.com/miolab/py_llm/assets/33124627/22d86f1f-0a29-408c-9144-39376d242e7d">
+    <img width="500" alt="image" src="https://github.com/miolab/py_llm/assets/33124627/8accdcfc-0ef8-4850-a69c-19576bb80018">
 
 ## Ref
 

--- a/src/function/token_utils.py
+++ b/src/function/token_utils.py
@@ -4,7 +4,7 @@ import tiktoken
 class TokenUtils:
     """A utility class for tokenization tasks.
     - This class uses a specific model to encode text into tokens and provides
-    information about the length of the text, the tokens, and the number of tokens.
+    information about the length of the text and the number of tokens.
 
     Attributes:
         model_name (str): The name of the model to use for tokenization.
@@ -25,12 +25,9 @@ class TokenUtils:
             text (str): The text to be encoded.
 
         Returns:
-            str: Text that contains information about the length of the text,
-                the tokens, and the number of tokens.
+            str: Information about the length of the text and the number of tokens.
         """
         encoding = tiktoken.encoding_for_model(self.model_name)
         tokens = encoding.encode(text)
 
-        return f"Text length: {len(text)}, \
-            Tokens: {tokens}, \
-            Tokens length: {len(tokens)}"
+        return f"Text length: {len(text)}, Tokens length: {len(tokens)}"

--- a/src/tests/test_token_utils.py
+++ b/src/tests/test_token_utils.py
@@ -1,0 +1,22 @@
+import pytest
+from src.function.token_utils import TokenUtils
+
+
+def test_encode_text_to_tokens(mocker):
+    mock_encoding_for_model = mocker.patch(
+        "src.function.token_utils.tiktoken.encoding_for_model"
+    )
+
+    # Set value returned by mock
+    mock_encoding = mocker.Mock()
+    mock_encoding.encode.return_value = [1, 2, 3]
+    mock_encoding_for_model.return_value = mock_encoding
+    assert len(mock_encoding.encode.return_value) == 3
+
+    model_name = "gpt-3.5-turbo"
+    tokenizer = TokenUtils(model_name)
+    text = "Test"
+
+    actual_result = tokenizer.encode_text_to_tokens(text)
+    expected_result = "Text length: 4, Tokens length: 3"
+    assert actual_result == expected_result


### PR DESCRIPTION
# About

`TokenUtils` class:

- Fix `test_encode_text_to_tokens` function's return value.
  | before | after |
  |:--|:--|
  |<img width="500" alt="image" src ="https://github.com/miolab/py_llm/assets/33124627/5542060c-b3e4-485b-af0c-ef8826ce68a8">|<img width="550" alt="image" src="https://github.com/miolab/py_llm/assets/33124627/8accdcfc-0ef8-4850-a69c-19576bb80018">|
- Add test.
